### PR TITLE
ajout vérification pré-requis sur les données

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,10 @@
   register: install
   apt: { name: ntpdate }
 
+- assert:
+    that: servers_configurations[inventory_hostname] is defined
+    fail_msg: "dans infra-data/vars/direct/ntp.yml, définir le serveur {{ inventory_hostname }} dans servers_configurations"
+
 - name: configure ntpdate
   register: configure
   template:


### PR DESCRIPTION
Le but est d'avoir un assert qui donne l'erreur exacte (oubli d'une déclaration), plutôt qu'une variable indéfinie